### PR TITLE
[change] project name with readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-# External API App
+# countries_info_app
 
 ## Project Overview
 A full-stack web application built with Django (backend) and React (frontend) to manage country information. Features include viewing, adding, updating, and deleting countries with pagination, search, and JWT-based authentication. The backend uses a PostgreSQL database and integrates with an external API for country data, while the frontend provides a responsive UI with Bulma CSS.
-GitHub Repository: https://github.com/almusfuad/external_api_app
+GitHub Repository: https://github.com/almusfuad/countries_info_app
 
 
 ## Cloning the Repository
 
 1. Clone the repository:
-   ```git clone https://github.com/almusfuad/external_api_app.git```
+   ```git clone https://github.com/almusfuad/countries_info_app.git```
 
 
 2. Navigate to the project directory:
-    ```cd external_api_app```
+    ```cd countries_info_app```
 
 
 

--- a/countries_info_app/asgi.py
+++ b/countries_info_app/asgi.py
@@ -1,5 +1,5 @@
 """
-ASGI config for external_api_app project.
+ASGI config for countries_info_app project.
 
 It exposes the ASGI callable as a module-level variable named ``application``.
 
@@ -11,6 +11,6 @@ import os
 
 from django.core.asgi import get_asgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'external_api_app.settings')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'countries_info_app.settings')
 
 application = get_asgi_application()

--- a/countries_info_app/settings.py
+++ b/countries_info_app/settings.py
@@ -41,7 +41,7 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
-ROOT_URLCONF = 'external_api_app.urls'
+ROOT_URLCONF = 'countries_info_app.urls'
 
 TEMPLATES = [
     {
@@ -59,7 +59,7 @@ TEMPLATES = [
     },
 ]
 
-WSGI_APPLICATION = 'external_api_app.wsgi.application'
+WSGI_APPLICATION = 'countries_info_app.wsgi.application'
 
 
 REST_FRAMEWORK = {

--- a/countries_info_app/urls.py
+++ b/countries_info_app/urls.py
@@ -1,5 +1,5 @@
 """
-URL configuration for external_api_app project.
+URL configuration for countries_info_app project.
 
 The `urlpatterns` list routes URLs to views. For more information please see:
     https://docs.djangoproject.com/en/5.2/topics/http/urls/

--- a/countries_info_app/wsgi.py
+++ b/countries_info_app/wsgi.py
@@ -1,5 +1,5 @@
 """
-WSGI config for external_api_app project.
+WSGI config for countries_info_app project.
 
 It exposes the WSGI callable as a module-level variable named ``application``.
 
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'external_api_app.settings')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'countries_info_app.settings')
 
 application = get_wsgi_application()

--- a/manage.py
+++ b/manage.py
@@ -6,7 +6,7 @@ import sys
 
 def main():
     """Run administrative tasks."""
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'external_api_app.settings')
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'countries_info_app.settings')
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:


### PR DESCRIPTION
## Summary by Sourcery

Rename project from 'external_api_app' to 'countries_info_app'

Documentation:
- Update README with new project name and repository URL

Chores:
- Update project name across configuration files and README